### PR TITLE
Fix CoNLL 2012 reader. fixes #172

### DIFF
--- a/src/test/java/de/unistuttgart/ims/coref/annotator/uima/TestCoNLL2012Reader.java
+++ b/src/test/java/de/unistuttgart/ims/coref/annotator/uima/TestCoNLL2012Reader.java
@@ -38,4 +38,24 @@ public class TestCoNLL2012Reader {
 				JCasUtil.selectByIndex(jcas, Sentence.class, 1).getCoveredText());
 		assertEquals(2, JCasUtil.select(jcas, Entity.class).size());
 	}
+
+	@Test
+	public void testReaderEnglish() throws ResourceInitializationException {
+		CollectionReaderDescription readerDesc = CollectionReaderFactory.createReaderDescription(CoNLL2012Reader.class,
+				CoNLL2012Reader.PARAM_SOURCE_LOCATION,
+				"src/test/resources/conll/2012/cnn_0122.conll");
+
+		JCas jcas = SimplePipeline
+				.iteratePipeline(readerDesc, AnalysisEngineFactory.createEngineDescription(NoOpAnnotator.class))
+				.iterator().next();
+
+		assertNotNull(jcas);
+		assertTrue(JCasUtil.exists(jcas, Sentence.class));
+		assertTrue(JCasUtil.exists(jcas, Token.class));
+		assertEquals("Israeli Prime Minister Ehud Barak is rejecting calls for a quick settlement with Palestinians to end the outbreak of violence in the Middle East .",
+				JCasUtil.selectByIndex(jcas, Sentence.class, 0).getCoveredText());
+		assertEquals("During a meeting of his cabinet , Barak criticized members of his own political party who have urged him to finalize an agreement before President Clinton leaves office next month .",
+				JCasUtil.selectByIndex(jcas, Sentence.class, 1).getCoveredText());
+		assertEquals(1, JCasUtil.select(jcas, Entity.class).size());
+	}
 }

--- a/src/test/resources/conll/2012/cnn_0122.conll
+++ b/src/test/resources/conll/2012/cnn_0122.conll
@@ -1,0 +1,78 @@
+#begin document (bn/cnn/01/cnn_0122); part 000
+bn/cnn/01/cnn_0122          0          0    Israeli         JJ (TOP(S(NP(NML*          -          -          -          -     (NORP)          *     (ARG0*          *         (0
+bn/cnn/01/cnn_0122          0          1      Prime        NNP          *          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          2   Minister        NNP         *)          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          3       Ehud        NNP          *          -          -          -          -   (PERSON*          *          *          *          -
+bn/cnn/01/cnn_0122          0          4      Barak        NNP         *)          -          -          -          -         *)          *         *)          *         0)
+bn/cnn/01/cnn_0122          0          5         is        VBZ       (VP*         be         03          -          -          *       (V*)          *          *          -
+bn/cnn/01/cnn_0122          0          6  rejecting        VBG       (VP*     reject         01          1          -          *          *       (V*)          *          -
+bn/cnn/01/cnn_0122          0          7      calls        NNS   (NP(NP*)          -          -          1          -          *          *     (ARG1*          *          -
+bn/cnn/01/cnn_0122          0          8        for         IN       (PP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          9          a         DT    (NP(NP*          -          -          -          -          *          *          *     (ARG0*          -
+bn/cnn/01/cnn_0122          0         10      quick         JJ          *          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         11 settlement         NN         *)          -          -          3          -          *          *          *         *)          -
+bn/cnn/01/cnn_0122          0         12       with         IN       (PP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         13 Palestinians       NNPS     (NP*))          -          -          -          -     (NORP)          *          *          *          -
+bn/cnn/01/cnn_0122          0         14         to         TO (SBAR(S(VP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         15        end         VB       (VP*        end         01          2          -          *          *          *       (V*)          -
+bn/cnn/01/cnn_0122          0         16        the         DT    (NP(NP*          -          -          -          -          *          *          *     (ARG1*          -
+bn/cnn/01/cnn_0122          0         17   outbreak         NN         *)          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         18         of         IN       (PP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         19   violence         NN     (NP*))          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         20         in         IN       (PP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         21        the         DT       (NP*          -          -          -          -      (LOC*          *          *          *          -
+bn/cnn/01/cnn_0122          0         22     Middle        NNP          *          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         23       East        NNP *))))))))))))          -          -          -          -         *)          *         *)         *)          -
+bn/cnn/01/cnn_0122          0         24          .          .        *))          -          -          -          -          *          *          *          *          -
+
+bn/cnn/01/cnn_0122          0          0     During         IN (TOP(S(PP*          -          -          -          -          * (ARGM-TMP*          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          1          a         DT    (NP(NP*          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          2    meeting         NN         *)          -          -          1          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          3         of         IN       (PP*          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          4        his       PRP$       (NP*          -          -          -          -          *          *          *          *          *          *        (0)
+bn/cnn/01/cnn_0122          0          5    cabinet         NN      *))))          -          -          -          -          *         *)          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          6          ,          ,          *          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          7      Barak        NNP      (NP*)          -          -          -          -   (PERSON)    (ARG0*)          *          *          *          *        (0)
+bn/cnn/01/cnn_0122          0          8 criticized        VBD       (VP*  criticize         01          1          -          *       (V*)          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          9    members        NNS (NP(NP(NP*)          -          -          1          -          *     (ARG1*          *     (ARG0*          *          *          -
+bn/cnn/01/cnn_0122          0         10         of         IN       (PP*          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         11        his       PRP$       (NP*          -          -          -          -          *          *          *          *          *          *        (0)
+bn/cnn/01/cnn_0122          0         12        own         JJ          *          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         13  political         JJ          *          -          -          -          -          *          *          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         14      party         NN       *)))          -          -          -          -          *          *          *         *)          *          *          -
+bn/cnn/01/cnn_0122          0         15        who         WP (SBAR(WHNP*)          -          -          -          -          *          *          *  (R-ARG0*)          *          *          -
+bn/cnn/01/cnn_0122          0         16       have        VBP     (S(VP*       have         01          -          -          *          *       (V*)          *          *          *          -
+bn/cnn/01/cnn_0122          0         17      urged        VBN       (VP*       urge         01          1          -          *          *          *       (V*)          *          *          -
+bn/cnn/01/cnn_0122          0         18        him        PRP      (NP*)          -          -          -          -          *          *          *    (ARG1*)    (ARG0*)          *        (0)
+bn/cnn/01/cnn_0122          0         19         to         TO     (S(VP*          -          -          -          -          *          *          *     (ARG2*          *          *          -
+bn/cnn/01/cnn_0122          0         20   finalize         VB       (VP*   finalize         01          -          -          *          *          *          *       (V*)          *          -
+bn/cnn/01/cnn_0122          0         21         an         DT       (NP*          -          -          -          -          *          *          *          *     (ARG1*          *          -
+bn/cnn/01/cnn_0122          0         22  agreement         NN         *)          -          -          1          -          *          *          *          *         *)          *          -
+bn/cnn/01/cnn_0122          0         23     before         IN     (SBAR*          -          -          -          -          *          *          *          * (ARGM-TMP*          *          -
+bn/cnn/01/cnn_0122          0         24  President        NNP     (S(NP*          -          -          -          -          *          *          *          *          *     (ARG0*          -
+bn/cnn/01/cnn_0122          0         25    Clinton        NNP         *)          -          -          -          -   (PERSON)          *          *          *          *         *)          -
+bn/cnn/01/cnn_0122          0         26     leaves        VBZ       (VP*      leave         01          1          -          *          *          *          *          *       (V*)          -
+bn/cnn/01/cnn_0122          0         27     office         NN      (NP*)          -          -          -          -          *          *          *          *          *    (ARG1*)          -
+bn/cnn/01/cnn_0122          0         28       next         JJ       (NP*          -          -          -          -     (DATE*          *          *          *          * (ARGM-TMP*          -
+bn/cnn/01/cnn_0122          0         29      month         NN *)))))))))))))          -          -          2          -         *)         *)          *         *)         *)         *)          -
+bn/cnn/01/cnn_0122          0         30          .          .        *))          -          -          -          -          *          *          *          *          *          *          -
+
+bn/cnn/01/cnn_0122          0          0         He        PRP (TOP(S(NP*)          -          -          -          -          *    (ARG0*)          *          *        (0)
+bn/cnn/01/cnn_0122          0          1   declared        VBD       (VP*    declare         02          1          -          *       (V*)          *          *          -
+bn/cnn/01/cnn_0122          0          2       that         IN     (SBAR*          -          -          -          -          *     (ARG1*          *          *          -
+bn/cnn/01/cnn_0122          0          3        any         DT     (S(NP*          -          -          -          -          *          *          *     (ARG1*          -
+bn/cnn/01/cnn_0122          0          4    attempt         NN          *          -          -          1          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          5         to         TO     (S(VP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          6         ``         ``       (VP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0          7    dictate         VB          *    dictate         01          1          -          *          *       (V*)          *          -
+bn/cnn/01/cnn_0122          0          8      dates        NNS      (NP*)          -          -          1          -          *          *    (ARG1*)          *          -
+bn/cnn/01/cnn_0122          0          9         ''         ''      *))))          -          -          -          -          *          *          *         *)          -
+bn/cnn/01/cnn_0122          0         10         is        VBZ       (VP*         be         01          1          -          *          *          *       (V*)          -
+bn/cnn/01/cnn_0122          0         11         ``         ``          *          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         12        bad         JJ     (ADJP*          -          -          -          -          *          *          *     (ARG2*          -
+bn/cnn/01/cnn_0122          0         13        for         IN       (PP*          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         14     Israel        NNP (NP*)))))))          -          -          -          -      (GPE)         *)          *         *)          -
+bn/cnn/01/cnn_0122          0         15          .          .          *          -          -          -          -          *          *          *          *          -
+bn/cnn/01/cnn_0122          0         16         ''         ''        *))          -          -          -          -          *          *          *          *          -
+
+#end document


### PR DESCRIPTION
- Always use last column for coreference information,
  following http://conll.cemantix.org/2012/data.html
- Accept columns delimited by either spaces or tabs
- Remove CSVReader, since it does not support delimiting by a regular
  expression, and we don't need quoting or escaping.
- Add test with file from CoNLL 2012 task trial data