### PR TITLE
Explicitly target Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,7 +545,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-nop</artifactId>
-			<version>2.0.0-alpha5</version>
+			<version>1.7.30</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,18 @@
 		<version.dkpro>2.2.0</version.dkpro>
 		<version.ikonli>12.2.0</version.ikonli>
 		<version.eclipse>10.2.0</version.eclipse>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 		<version.javafx>14.0.2.1</version.javafx>
 	</properties>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.uima</groupId>
 				<artifactId>jcasgen-maven-plugin</artifactId>
@@ -471,6 +477,12 @@
 		<dependency>
 			<groupId>org.dkpro.core</groupId>
 			<artifactId>dkpro-core-stanfordnlp-gpl</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>
@@ -512,6 +524,12 @@
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
 			<version>4.1.2</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>xml-apis</artifactId>
+					<groupId>xml-apis</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.knowm.xchart</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.12</version>
+			<version>0.10.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -487,12 +487,12 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20151123</version>
+			<version>20210307</version>
 		</dependency>
 		<dependency>
 			<groupId>de.unistuttgart.ims.uima.io</groupId>
 			<artifactId>generic-xml-reader</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.lexicalscope.jewelcli</groupId>
@@ -502,7 +502,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>3.4.4</version>
+			<version>4.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -518,12 +518,12 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>4.1.2</version>
+			<version>5.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.1.2</version>
+			<version>5.1.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>xml-apis</artifactId>
@@ -539,12 +539,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.8</version>
+			<version>1.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-nop</artifactId>
-			<version>1.7.30</version>
+			<version>2.0.0-alpha5</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 							<manifestEntries>
 								<Main-Class>de.unistuttgart.ims.coref.annotator.Annotator</Main-Class>
 								<Build-Number>${project.version}</Build-Number>
+								<Multi-Release>true</Multi-Release>
 							</manifestEntries>
 						</transformer>
 						<transformer


### PR DESCRIPTION
The code already uses methods that were only introduced with Java 11 (e.g. `String.isBlank()`) and thus depends on Java 11 without it being explicitly set in the Maven configuration. Also, Java 11 (LTS) is already 3 years old. By now it should be okay to draw a line and make the project's setup more explicit about it's target platform.

- This PR attempts to properly **target Java 11** by using the [maven-compiler-plugin](https://maven.apache.org/plugins/maven-compiler-plugin/) (e.g. as explained [here](https://www.baeldung.com/maven-java-version)). By changing the target platform to Java 11, some project dependencies include packages that found their way into the standard library of Java 11 by now, resulting in duplicate packages in the build path. This is **fixed by excluding said packages from the dependency tree** (namely `xml-apis` is excluded from `org.apache.poi.poi-ooxml` and `org.dkpro.core.dkpro-core-stanfordnlp-gpl`) and instead relying on the Java platform packages.

- This PR **does not update the project's dependencies!** While this would be a good idea in general, it _might_ or _might not_ be necessary right now. The currently used dependencies' compatibility with Java 11 should still be tested before merging, making this a work-in-progress (draft) PR.

- This PR would resolve #265 by rendering it irrelevant