### PR TITLE
Implement CSV export for ExportMultipleFiles tool

### DIFF
--- a/src/main/java/de/unistuttgart/ims/coref/annotator/plugin/csv/CsvExportPlugin.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/plugin/csv/CsvExportPlugin.java
@@ -32,8 +32,12 @@ import de.unistuttgart.ims.coref.annotator.plugins.PluginOption.BooleanPluginOpt
 import de.unistuttgart.ims.coref.annotator.plugins.UimaExportPlugin;
 import javafx.stage.FileChooser.ExtensionFilter;
 
-public class CsvExportPlugin extends AbstractExportPlugin implements UimaExportPlugin, ConfigurableExportPlugin {
 
+public class CsvExportPlugin
+		extends AbstractExportPlugin
+		implements UimaExportPlugin, ConfigurableExportPlugin {
+
+	
 	public static enum ContextUnit {
 		CHARACTER, TOKEN, LINE;
 
@@ -66,13 +70,26 @@ public class CsvExportPlugin extends AbstractExportPlugin implements UimaExportP
 
 	@Override
 	public AnalysisEngineDescription getWriter(File f) throws ResourceInitializationException {
+		
 		AggregateBuilder b = new AggregateBuilder();
-		b.add(AnalysisEngineFactory.createEngineDescription(CSVWriter.class, CSVWriter.PARAM_FILE, f.getAbsolutePath(),
-				CSVWriter.PARAM_CONTEXTWIDTH, getOptionContextWidth(), CSVWriter.PARAM_REPLACE_NEWLINES,
-				isOptionReplaceNewlines(), CSVWriter.PARAM_TRIM_WHITESPACE, isOptionTrimWhitespace(),
-				CSVWriter.PARAM_CONTEXT_UNIT, getOptionContextUnit(), CSVWriter.PARAM_INCLUDE_LINE_NUMBERS,
-				Annotator.app.getPreferences().getBoolean(Constants.PLUGIN_CSV_INCLUDE_LINE_NUMBERS,
-						Defaults.CFG_OPTION_INCLUDE_LINE_NUMBERS)));
+		b.add(AnalysisEngineFactory.createEngineDescription(
+				CSVWriter.class,
+				CSVWriter.PARAM_FILE,
+				f.getAbsolutePath(),
+				CSVWriter.PARAM_CONTEXTWIDTH,
+				getOptionContextWidth(),
+				CSVWriter.PARAM_REPLACE_NEWLINES,
+				isOptionReplaceNewlines(),
+				CSVWriter.PARAM_TRIM_WHITESPACE,
+				isOptionTrimWhitespace(),
+				CSVWriter.PARAM_CONTEXT_UNIT,
+				getOptionContextUnit(),
+				CSVWriter.PARAM_INCLUDE_LINE_NUMBERS,
+				Annotator.app != null
+						? Annotator.app.getPreferences().getBoolean(
+							Constants.PLUGIN_CSV_INCLUDE_LINE_NUMBERS,
+							Defaults.CFG_OPTION_INCLUDE_LINE_NUMBERS)
+						: Defaults.CFG_OPTION_INCLUDE_LINE_NUMBERS));
 		return b.createAggregateDescription();
 	}
 
@@ -104,57 +121,101 @@ public class CsvExportPlugin extends AbstractExportPlugin implements UimaExportP
 	}
 
 	@Override
-	public void showExportConfigurationDialog(JFrame parent, DocumentModel documentModel,
+	public void showExportConfigurationDialog(
+			JFrame parent,
+			DocumentModel documentModel,
 			Consumer<ConfigurableExportPlugin> callback) {
 
 		ImmutableList<PluginOption> options = Lists.immutable.of(
-				new PluginOption.IntegerPluginOption(Annotator.app.getPreferences(), Constants.PLUGIN_CSV_CONTEXT_WIDTH,
-						Defaults.CFG_OPTION_CONTEXT_WIDTH, "dialog.export_options.context_width",
-						"dialog.export_options.context_width.tooltip", 0, 500, 25),
-				(PluginOption) new PluginOption.EnumPluginOption<ContextUnit>(ContextUnit.class,
-						Annotator.app.getPreferences(), Constants.PLUGIN_CSV_CONTEXT_UNIT,
-						Defaults.CFG_OPTION_CONTEXT_UNIT, "dialog.export_options.context_unit",
-						"dialog.export_options.context_unit.tooltip", Lists.immutable.of(ContextUnit.values())
-								.select(cu -> cu.isPossible(documentModel.getJcas())).toArray(new ContextUnit[] {}),
+				new PluginOption.IntegerPluginOption(
+						Annotator.app.getPreferences(),
+						Constants.PLUGIN_CSV_CONTEXT_WIDTH,
+						Defaults.CFG_OPTION_CONTEXT_WIDTH,
+						"dialog.export_options.context_width",
+						"dialog.export_options.context_width.tooltip",
+						0,
+						500,
+						25),
+				(PluginOption) new PluginOption.EnumPluginOption<ContextUnit>(
+						ContextUnit.class,
+						Annotator.app.getPreferences(),
+						Constants.PLUGIN_CSV_CONTEXT_UNIT,
+						Defaults.CFG_OPTION_CONTEXT_UNIT,
+						"dialog.export_options.context_unit",
+						"dialog.export_options.context_unit.tooltip",
+						Lists.immutable.of(ContextUnit.values())
+								.select(cu -> cu.isPossible(
+										documentModel.getJcas()))
+								.toArray(new ContextUnit[] {}),
 						new DefaultListCellRenderer() {
 							private static final long serialVersionUID = 1L;
 
 							@Override
-							public Component getListCellRendererComponent(JList<?> list, Object value, int index,
-									boolean isSelected, boolean cellHasFocus) {
-								super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-								setText(Annotator.getString("dialog.export_options.context_unit." + value.toString()));
+							public Component getListCellRendererComponent(
+									JList<?> list,
+									Object value,
+									int index,
+									boolean isSelected,
+									boolean cellHasFocus) {
+								super.getListCellRendererComponent(
+										list, value, index, isSelected, cellHasFocus);
+								setText(Annotator.getString(
+										"dialog.export_options.context_unit." + value.toString()));
 								return this;
 							}
 						}),
-				new BooleanPluginOption(Annotator.app.getPreferences(), Constants.PLUGIN_CSV_TRIM,
-						Defaults.CFG_OPTION_TRIM, "dialog.export_options.trim_whitespace",
+				new BooleanPluginOption(
+						Annotator.app.getPreferences(),
+						Constants.PLUGIN_CSV_TRIM,
+						Defaults.CFG_OPTION_TRIM,
+						"dialog.export_options.trim_whitespace",
 						"dialog.export_options.trim_whitespace.tooltip"),
-				new BooleanPluginOption(Annotator.app.getPreferences(), Constants.PLUGIN_CSV_REPLACE_NEWLINES,
-						Defaults.CFG_OPTION_REPLACE_NEWLINES, "dialog.export_options.replace_newline",
+				new BooleanPluginOption(
+						Annotator.app.getPreferences(),
+						Constants.PLUGIN_CSV_REPLACE_NEWLINES,
+						Defaults.CFG_OPTION_REPLACE_NEWLINES,
+						"dialog.export_options.replace_newline",
 						"dialog.export_options.replace_newline.tooltip"),
-				new BooleanPluginOption(Annotator.app.getPreferences(), Constants.PLUGIN_CSV_INCLUDE_LINE_NUMBERS,
-						Defaults.CFG_OPTION_INCLUDE_LINE_NUMBERS, "dialog.export_options.include_line_numbers",
+				new BooleanPluginOption(
+						Annotator.app.getPreferences(),
+						Constants.PLUGIN_CSV_INCLUDE_LINE_NUMBERS,
+						Defaults.CFG_OPTION_INCLUDE_LINE_NUMBERS,
+						"dialog.export_options.include_line_numbers",
 						"dialog.export_options.include_line_numbers.tooltip"));
 
 		new PluginConfigurationDialog(parent, this, callback, options).setVisible(true);
 	}
 
 	public int getOptionContextWidth() {
-		return Annotator.app.getPreferences().getInt((Constants.PLUGIN_CSV_CONTEXT_WIDTH), 30);
+		return Annotator.app != null
+				? Annotator.app.getPreferences().getInt(
+						Constants.PLUGIN_CSV_CONTEXT_WIDTH,
+						Defaults.CFG_OPTION_CONTEXT_WIDTH)
+				: Defaults.CFG_OPTION_CONTEXT_WIDTH;
 	}
 
 	public boolean isOptionTrimWhitespace() {
-		return Annotator.app.getPreferences().getBoolean((Constants.PLUGIN_CSV_TRIM), true);
+		return Annotator.app != null
+				? Annotator.app.getPreferences().getBoolean(
+						Constants.PLUGIN_CSV_TRIM,
+						Defaults.CFG_OPTION_TRIM)
+				: Defaults.CFG_OPTION_TRIM;
 	}
 
 	public boolean isOptionReplaceNewlines() {
-		return Annotator.app.getPreferences().getBoolean((Constants.PLUGIN_CSV_REPLACE_NEWLINES), true);
+		return Annotator.app != null
+				? Annotator.app.getPreferences().getBoolean(
+						Constants.PLUGIN_CSV_REPLACE_NEWLINES,
+						Defaults.CFG_OPTION_REPLACE_NEWLINES)
+				: Defaults.CFG_OPTION_REPLACE_NEWLINES;
 	}
 
 	public ContextUnit getOptionContextUnit() {
-		return ContextUnit.valueOf(
-				Annotator.app.getPreferences().get((Constants.PLUGIN_CSV_CONTEXT_UNIT), ContextUnit.CHARACTER.name()));
+		return Annotator.app != null
+				? ContextUnit.valueOf(Annotator.app.getPreferences().get(
+						Constants.PLUGIN_CSV_CONTEXT_UNIT,
+						Defaults.CFG_OPTION_CONTEXT_UNIT.name()))
+				: ContextUnit.valueOf(Defaults.CFG_OPTION_CONTEXT_UNIT.name());
 	}
 
 }

--- a/src/main/java/de/unistuttgart/ims/coref/annotator/plugin/csv/Defaults.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/plugin/csv/Defaults.java
@@ -3,6 +3,7 @@ package de.unistuttgart.ims.coref.annotator.plugin.csv;
 import de.unistuttgart.ims.coref.annotator.plugin.csv.CsvExportPlugin.ContextUnit;
 
 public class Defaults {
+	
 	public static final int CFG_OPTION_CONTEXT_WIDTH = 30;
 	public static final ContextUnit CFG_OPTION_CONTEXT_UNIT = ContextUnit.CHARACTER;
 	public static final boolean CFG_OPTION_TRIM = true;

--- a/src/main/java/de/unistuttgart/ims/coref/annotator/tools/ExportMultipleFiles.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/tools/ExportMultipleFiles.java
@@ -36,13 +36,12 @@ import de.unistuttgart.ims.coref.annotator.worker.JCasLoader;
  *
  */
 public class ExportMultipleFiles {
+	
 	static Options options;
-
 	static ExportPlugin outputPlugin;
-
 	static Pattern filenamePattern = Pattern.compile("^(.*)\\.xmi(\\.gz)?");
-
 	static PluginManager pluginManager;
+	
 
 	public static void main(String[] args)
 			throws ResourceInitializationException, ClassNotFoundException, InterruptedException, ExecutionException {
@@ -80,6 +79,7 @@ public class ExportMultipleFiles {
 		}
 	}
 
+	
 	/**
 	 * This function processes a single file.
 	 * 
@@ -123,9 +123,12 @@ public class ExportMultipleFiles {
 		w.get();
 	}
 
+	
 	public enum OutputFormat {
-		tei, conll2012, json, qdtei, stats;
+		
+		tei, conll2012, json, csv, qdtei, stats;
 
+		@SuppressWarnings("unchecked")
 		Class<? extends ExportPlugin> getPluginClass() {
 			switch (this) {
 			case stats:
@@ -136,6 +139,8 @@ public class ExportMultipleFiles {
 				return de.unistuttgart.ims.coref.annotator.plugin.json.Plugin.class;
 			case tei:
 				return de.unistuttgart.ims.coref.annotator.plugin.tei.TeiExportPlugin.class;
+			case csv:
+				return de.unistuttgart.ims.coref.annotator.plugin.csv.CsvExportPlugin.class;
 			case qdtei:
 				// This is a temporary workaround
 				try {
@@ -152,16 +157,18 @@ public class ExportMultipleFiles {
 
 	}
 
+	
 	public enum OutputFilename {
 		input, documentId
 	}
 
+	
 	@CommandLineInterface(application = "ExportMultipleFiles")
 	public interface Options {
 		@Option(description = "Input file or directory.", shortName = "i")
 		List<File> getInput();
 
-		@Option(defaultValue = "tei", description = "Target format. One of [tei, conll2012, json].")
+		@Option(defaultValue = "tei", description = "Target format. One of [tei, conll2012, json, csv, stats].")
 		OutputFormat getOutputFormat();
 
 		@Option(defaultValue = ".", description = "Output directory. Defaults to current.", shortName = "o")
@@ -173,4 +180,5 @@ public class ExportMultipleFiles {
 		@Option(helpRequest = true, shortName = "h", description = "Show help")
 		boolean getHelp();
 	}
+	
 }


### PR DESCRIPTION
This PR implements a CSV export for the `ExportMultipleFiles` command line tool.  
It uses the existing `CsvExportPlugin`, modified to use the existing default option values in case there is no `Annotator` instance running to pull option values from (which is the case in command line context).

There was also some code formatting done in `CsvExportPlugin` to maintain a more readable 100 char code width and tidy up some sprawling method calls.

Also, a mention of the `stats` option was added to the `--help` output of the `ExportMultipleFiles` tool, as it was missing but the export of stats seems to work fine. The info for `qdtei` is missing, too. But I cannot judge whether this one works as intended or is still a work-in-progress feature.

This would close #370.