### PR TITLE
Fix #381

### DIFF
--- a/src/main/java/de/unistuttgart/ims/coref/annotator/Annotator.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/Annotator.java
@@ -465,8 +465,7 @@ public class Annotator implements PreferenceChangeListener {
 
 	private void recentFiles2Preferences(MutableList<File> recentFiles) {
 		StringBuilder sb = new StringBuilder();
-		for (int index = 0; index < recentFiles.size(); index++) {
-			File file = recentFiles.get(index);
+		for (File file : recentFiles) {
 			if (sb.length() > 0) {
 				sb.append(File.pathSeparator);
 			}
@@ -481,7 +480,6 @@ public class Annotator implements PreferenceChangeListener {
 		for (int i = 0; i < Math.min(20, recentFiles.size()); i++)
 			m.add(new SelectedFileOpenAction(this, recentFiles.get(i)));
 		return m;
-
 	}
 
 	public Preferences getPreferences() {

--- a/src/main/java/de/unistuttgart/ims/coref/annotator/DocumentWindow.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/DocumentWindow.java
@@ -1610,27 +1610,33 @@ public class DocumentWindow extends AbstractTextWindow implements CaretListener,
 			StringBuilder b = new StringBuilder();
 			b.append(m.getAddress());
 
-			String surf = UimaUtil.getCoveredText(m);
-			surf = StringUtils.abbreviateMiddle(surf, "...", 20);
+			String mention = StringUtils
+					.abbreviateMiddle(UimaUtil.getCoveredText(m), "...", 20);
 
-			if (m.getEntity().getLabel() != null)
-				b.append(": ")
-						.append(StringUtils.abbreviateMiddle(
-								getDocumentModel().getCoreferenceModel().getLabel(m.getEntity()), "...",
-								Constants.UI_MAX_STRING_WIDTH_IN_MENU));
-
+			if (m.getEntity().getLabel() != null) {
+				String entity = StringUtils.abbreviateMiddle(
+						getDocumentModel().getCoreferenceModel().getLabel(m.getEntity()), "...",
+						Constants.UI_MAX_STRING_WIDTH_IN_MENU / 2);
+				b.append(String.format(": %s (%s)", mention, entity));
+			}
+			
 			JMenu mentionMenu = new JMenu(b.toString());
 			mentionMenu.setIcon(FontIcon.of(MaterialDesign.MDI_ACCOUNT, new Color(m.getEntity().getColor())));
 			Action a = new ShowMentionInTreeAction(DocumentWindow.this, m);
-			mentionMenu.add('"' + surf + '"');
+			mentionMenu.add(String.format("\"%s\"", mention));
+			mentionMenu.getItem(mentionMenu.getItemCount() - 1).setEnabled(false);
 			mentionMenu.add(a);
 			mentionMenu.add(new DeleteAction(DocumentWindow.this, m));
-			if (m.getSurface().size() > 0)
+			
+			if (m.getSurface().size() > 1) {
 				for (MentionSurface ms : m.getSurface()) {
-					JMenu mentionSurfaceMenu = new JMenu(StringUtils.abbreviateMiddle(ms.getCoveredText(), "...", 20));
+					JMenu mentionSurfaceMenu = new JMenu(StringUtils.abbreviateMiddle(
+							ms.getCoveredText(), "...",
+							Constants.UI_MAX_STRING_WIDTH_IN_MENU));
 					mentionSurfaceMenu.add(new DeleteAction(DocumentWindow.this, ms));
 					mentionMenu.add(mentionSurfaceMenu);
 				}
+			}
 
 			return mentionMenu;
 		}

--- a/src/main/java/de/unistuttgart/ims/coref/annotator/document/EntityTreeModel.java
+++ b/src/main/java/de/unistuttgart/ims/coref/annotator/document/EntityTreeModel.java
@@ -123,9 +123,9 @@ public class EntityTreeModel extends DefaultTreeModel implements CoreferenceMode
 					if (etn != null) {
 						etn.removeAllChildren();
 						removeNodeFromParent(etn);
+						etn.modify();
 					}
 					fsMap.remove(event.getArgument(i));
-					etn.modify();
 				}
 			optResort();
 			break;


### PR DESCRIPTION
# This PR (mainly) fixes #381 

...which describes a bug in deleting a single mention surface (a runtime exception was thrown, therefore the subsequent code for removing the visual representation of the surface from the UI was not executed). Also, some improvements of the UI's representation of the selected items inside the popup menus was made (see below).


##  #381 

The error was quite simple: In `EntityTreeModel`'s `entityEvent()` method, incoming entity events are matched and executed. In case of a `Remove` event for a single mention surface (of a composite mention), the existing code tried to handle the event's targets as full entity nodes. There _was_ a `null`-check, but one line accessing the `CATreeNode` reference (which is `null` in case of a single surface) was just outside the respective conditional:

```java
CATreeNode etn = fsMap.get(event.getArgument(i));
if (etn != null) {
    etn.removeAllChildren();
    removeNodeFromParent(etn);
}
fsMap.remove(event.getArgument(i));
etn.modify(); // <--  :(
```

The functionality of this line doesn't depend on the line before. So moving it into the conditional was a safe operation. Deleting a single mention surface now works as expected.


## Further improvements in the context of the above bug

As mentioned in the comments to #381, the labeling of mentions, surfaces and entities that are (or aren't) target of an in-text operation via the right-click popup menu were a little misleading. I tried to improve this situation by making the following changes:

- disable the purely decorative menu item used as a heading in the sub-menu for a specific mention
- expand the textual representation of the mentions inside the popup menu (see below)

As these "cosmetical" improvements don't play a direct role in the bug mentioned in #381, I am very happy to remove them from this PR if they're not wanted (it _is_ possible that I misunderstood those labels 🙄).


## Preview of the changes

![screen_2021-12-13 14-47](https://user-images.githubusercontent.com/9215743/145823880-882a0235-692b-4c93-9377-8b417c4857c9.gif)

